### PR TITLE
Added PE ratio, marketcap calculation using yahoo finance api

### DIFF
--- a/src/app/api/finance/route.js
+++ b/src/app/api/finance/route.js
@@ -8,9 +8,9 @@ const round2Decimal = (value) => {
 };
 
 export function extractFinancials(data) {
-  const { price, defaultKeyStatistics } = data;
+  const { price, defaultKeyStatistics } = data || {};
 
-  const { regularMarketPrice, marketCap } = price;
+  const { regularMarketPrice, marketCap } = price || {};
   const {
     netIncomeToCommon,
     sharesOutstanding,
@@ -48,7 +48,14 @@ export async function GET(req) {
     const interval = searchParams.get("interval");
     const fromDate = searchParams.get("fromDate");
     const toDate = searchParams.get("toDate");
-    const isQuote = searchParams.get("isQuote");
+    const isQuote = searchParams.get("isQuote") === "true";
+
+    if (!symbol || !/^[A-Za-z0-9.\-^=]+$/.test(symbol)) {
+      return NextResponse.json(
+        { error: "Invalid or missing symbol." },
+        { status: 400 }
+      );
+    }
 
     const queryObj = {
       interval,


### PR DESCRIPTION
Added PE ratio, marketcap calculation using yahoo finance api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a Fundamentals table in Technical Info showing Current Price, Market Cap (Cr), EPS (TTM), and P/E Ratio.
  - Technical Info now fetches fundamentals automatically alongside existing technical data.

- Improvements
  - Symbols are resolved more reliably using available Yahoo symbols with regional fallback.
  - Numeric outputs standardized to two-decimal formatting; missing values show “N/A”.

- Bug Fixes
  - Early validation for missing/invalid symbols returns a clear 400 error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->