### PR TITLE
remove the hover tooltip logic and use only the mobile click/accordion behavior for all screen sizes in sidebar

### DIFF
--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -13,7 +13,6 @@ import { FaShapes } from "react-icons/fa";
 import TooltipSubMenu from "./toolTipMenu";
 import styles from "./Sidebar.module.scss";
 import getPatternArr from "./patternArr";
-// import watchlistArray from "../utils/watchListArr";
 import { getStorageData } from "../utils/storage";
 
 const Sidebar = ({
@@ -40,103 +39,49 @@ const Sidebar = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const toggleSidebar = () => {
-    setIsOpen(!isOpen);
-  };
-
-  const closeSidebar = () => {
-    setIsOpen(false);
-  };
+  const toggleSidebar = () => setIsOpen((prev) => !prev);
+  const closeSidebar = () => setIsOpen(false);
 
   const indicatorArr = [
     { id: "sma", name: "SMA(20,50,200)", isActive: indicatorName === "sma" },
     { id: "ema", name: "EMA", isActive: indicatorName === "ema" },
     { id: "rsi", name: "RSI", isActive: indicatorName === "rsi" },
     { id: "macd", name: "MACD(12,26,9)", isActive: indicatorName === "macd" },
-    {
-      id: "bolinger",
-      name: "Bolinger Band(20,2)",
-      isActive: indicatorName === "bolinger",
-    },
-    {
-      id: "zerolagmacd",
-      name: "ZERO LAG MACD(12,26,9)",
-      isActive: indicatorName === "zerolagmacd",
-    },
+    { id: "bolinger", name: "Bolinger Band(20,2)", isActive: indicatorName === "bolinger" },
+    { id: "zerolagmacd", name: "ZERO LAG MACD(12,26,9)", isActive: indicatorName === "zerolagmacd" },
     { id: "dmi", name: "DMI", isActive: indicatorName === "dmi" },
-    {
-      id: "mfi",
-      name: "MFI(14)",
-      isActive: indicatorName === "mfi",
-    },
-    {
-      id: "cci",
-      name: "CCI(20)",
-      isActive: indicatorName === "cci",
-    },
-    {
-      id: "sto",
-      name: "Stochastic(20,3)",
-      isActive: indicatorName === "sto",
-    },
-    {
-      id: "supertrend",
-      name: "SUPERTREND",
-      isActive: indicatorName === "supertrend",
-    },
+    { id: "mfi", name: "MFI(14)", isActive: indicatorName === "mfi" },
+    { id: "cci", name: "CCI(20)", isActive: indicatorName === "cci" },
+    { id: "sto", name: "Stochastic(20,3)", isActive: indicatorName === "sto" },
+    { id: "supertrend", name: "SUPERTREND", isActive: indicatorName === "supertrend" },
     { id: "obv", name: "OBV", isActive: indicatorName === "obv" },
   ];
+
   const positionArr = [
     { id: "long", name: "Long Position", isActive: positionName === "long" },
     { id: "short", name: "Short Position", isActive: positionName === "short" },
   ];
+
   const shapeArr = [
     { id: "circle", name: "Circle", isActive: shapeName === "circle" },
     { id: "rectangle", name: "Rectangle", isActive: shapeName === "rectangle" },
   ];
 
   const breakoutsArr = [
-    {
-      id: "CE",
-      name: "Chandelier Exit",
-      isActive: breakoutName === "CE",
-    },
-    {
-      id: "buysell",
-      name: "Buy and Sell(20) (Not ready)",
-      isActive: breakoutName === "buysell",
-    },
-    {
-      id: "volume",
-      name: "Volume (MA20)",
-      isActive: breakoutName === "volume",
-    },
-    {
-      id: "support",
-      name: "Support & Resistance (MA20)",
-      isActive: breakoutName === "support",
-    },
+    { id: "CE", name: "Chandelier Exit", isActive: breakoutName === "CE" },
+    { id: "buysell", name: "Buy and Sell(20) (Not ready)", isActive: breakoutName === "buysell" },
+    { id: "volume", name: "Volume (MA20)", isActive: breakoutName === "volume" },
+    { id: "support", name: "Support & Resistance (MA20)", isActive: breakoutName === "support" },
   ];
 
   const crossOverArr = [
-    {
-      id: "5-20-sma",
-      name: "5 & 20 SMA",
-      isActive: indicatorName === "5-20-sma",
-    },
-    {
-      id: "20-50-sma",
-      name: "20 & 50 SMA",
-      isActive: indicatorName === "20-50-sma",
-    },
-    {
-      id: "50-200-sma",
-      name: "50 & 200 SMA",
-      isActive: indicatorName === "50-200-sma",
-    },
+    { id: "5-20-sma", name: "5 & 20 SMA", isActive: indicatorName === "5-20-sma" },
+    { id: "20-50-sma", name: "20 & 50 SMA", isActive: indicatorName === "20-50-sma" },
+    { id: "50-200-sma", name: "50 & 200 SMA", isActive: indicatorName === "50-200-sma" },
   ];
 
   const patternArr = getPatternArr(patternName);
+
   const watchlistArray1 = getStorageData();
   watchlistArray1.forEach((v) => {
     v.isActive = companyObj.value === v.value;
@@ -144,174 +89,94 @@ const Sidebar = ({
 
   return (
     <>
-      {/* Toggle button — shows hamburger when closed, X when open */}
-      {isOpen ? (
-        <div className={styles.closeBtn} onClick={toggleSidebar}>
-          <FaTimes />
-        </div>
-      ) : (
-        <div className={styles.hamburger} onClick={toggleSidebar}>
-          <FaBars />
-        </div>
-      )}
+      <button
+        type="button"
+        className={styles.hamburger}
+        onClick={toggleSidebar}
+        aria-label={isOpen ? "Close sidebar" : "Open sidebar"}
+      >
+        {isOpen ? <FaTimes /> : <FaBars />}
+      </button>
 
-      {isOpen ? (
-        <button
-          type="button"
-          className={styles.closeBtn}
-          onClick={toggleSidebar}
-          aria-label="Close sidebar"
-        >
-          <FaTimes />
-        </button>
-      ) : (
-        <button
-          type="button"
-          className={styles.hamburger}
-          onClick={toggleSidebar}
-          aria-label="Open sidebar"
-        >
-          <FaBars />
-        </button>
-      )}
-
-
-      {/* Overlay — tap outside to close on mobile */}
       {isOpen && (
         <div className={styles.overlay} onClick={closeSidebar} />
       )}
 
-      {/* Sidebar */}
       <div className={`${styles.sidebar} ${isOpen ? styles.open : ""}`}>
         <div
           className={`${styles.button} ${trendLineEnable ? styles.active : ""}`}
-          onClick={(e) => {
-            closeSidebar();
-            handleTrendLineClick(e);
-          }}
+          onClick={() => { closeSidebar(); handleTrendLineClick(); }}
         >
           <MdTrendingFlat className={styles.icon} />
           <span>Trendline</span>
         </div>
+
         <div
           className={`${styles.button} ${textEnable ? styles.active : ""}`}
-          onClick={(e) => {
-            closeSidebar();
-            handleTextClick(e);
-          }}
+          onClick={() => { closeSidebar(); handleTextClick(); }}
         >
           <CiText className={styles.icon} />
           <span>Text</span>
         </div>
+
         <div
-          className={`${styles.button} ${measurementEnable ? styles.active : ""
-            }`}
-          onClick={(e) => {
-            closeSidebar();
-            handleMeasurementClick(e);
-          }}
+          className={`${styles.button} ${measurementEnable ? styles.active : ""}`}
+          onClick={() => { closeSidebar(); handleMeasurementClick(); }}
         >
           <LiaRulerHorizontalSolid className={styles.icon} />
           <span>Measurement</span>
         </div>
+
         <TooltipSubMenu
           styles={styles}
-          tooltipObj={{
-            name: "WatchList",
-            icon: <CiViewList className={styles.icon} />,
-            subMenu: watchlistArray1,
-          }}
-          onClick={(e, id) => {
-            closeSidebar();
-            handleWatchListClick(id);
-          }}
+          tooltipObj={{ name: "WatchList", icon: <CiViewList className={styles.icon} />, subMenu: watchlistArray1 }}
+          onClick={(e, id) => { closeSidebar(); handleWatchListClick(id); }}
         />
+
         <TooltipSubMenu
           styles={styles}
-          tooltipObj={{
-            name: "Indicator",
-            icon: <GrIndicator className={styles.icon} />,
-            subMenu: indicatorArr,
-          }}
-          onClick={(e, id) => {
-            closeSidebar();
-            handleIndicatorClick(id);
-          }}
+          tooltipObj={{ name: "Indicator", icon: <GrIndicator className={styles.icon} />, subMenu: indicatorArr }}
+          onClick={(e, id) => { closeSidebar(); handleIndicatorClick(id); }}
         />
+
         <TooltipSubMenu
           styles={styles}
-          tooltipObj={{
-            name: "MACrossOver",
-            icon: <MdPattern className={styles.icon} />,
-            subMenu: crossOverArr,
-          }}
-          onClick={(e, id) => {
-            closeSidebar();
-            handleIndicatorClick(id);
-          }}
+          tooltipObj={{ name: "MACrossOver", icon: <MdPattern className={styles.icon} />, subMenu: crossOverArr }}
+          onClick={(e, id) => { closeSidebar(); handleIndicatorClick(id); }}
         />
-        {indicatorName === "ema" ? (
+
+        {indicatorName === "ema" && (
           <div
-            className={`${styles.button} ${isAngleEnabled ? styles.active : ""
-              }`}
-            onClick={(e) => {
-              closeSidebar();
-              handleEMAangleClick(e);
-            }}
+            className={`${styles.button} ${isAngleEnabled ? styles.active : ""}`}
+            onClick={() => { closeSidebar(); handleEMAangleClick(); }}
           >
             <MdOutlineRotate90DegreesCw className={styles.icon} />
             <span>EMA Angle</span>
           </div>
-        ) : (
-          ""
         )}
+
         <TooltipSubMenu
           styles={styles}
-          tooltipObj={{
-            name: "Position",
-            icon: <FcPositiveDynamic className={styles.icon} />,
-            subMenu: positionArr,
-          }}
-          onClick={(e, id) => {
-            closeSidebar();
-            handlePositionClick(id);
-          }}
+          tooltipObj={{ name: "Position", icon: <FcPositiveDynamic className={styles.icon} />, subMenu: positionArr }}
+          onClick={(e, id) => { closeSidebar(); handlePositionClick(id); }}
         />
+
         <TooltipSubMenu
           styles={styles}
-          tooltipObj={{
-            name: "Shapes",
-            icon: <FaShapes className={styles.icon} />,
-            subMenu: shapeArr,
-          }}
-          onClick={(e, id) => {
-            closeSidebar();
-            handleShapeClick(id);
-          }}
+          tooltipObj={{ name: "Shapes", icon: <FaShapes className={styles.icon} />, subMenu: shapeArr }}
+          onClick={(e, id) => { closeSidebar(); handleShapeClick(id); }}
         />
+
         <TooltipSubMenu
           styles={styles}
-          tooltipObj={{
-            name: "Breakout",
-            icon: <FcBullish className={styles.icon} />,
-            subMenu: breakoutsArr,
-          }}
-          onClick={(e, id) => {
-            closeSidebar();
-            handleBreakoutClick(id);
-          }}
+          tooltipObj={{ name: "Breakout", icon: <FcBullish className={styles.icon} />, subMenu: breakoutsArr }}
+          onClick={(e, id) => { closeSidebar(); handleBreakoutClick(id); }}
         />
+
         <TooltipSubMenu
           styles={styles}
-          tooltipObj={{
-            name: "Pattern",
-            icon: <MdPattern className={styles.icon} />,
-            subMenu: patternArr,
-          }}
-          onClick={(e, id) => {
-            closeSidebar();
-            handlePatternClick(id);
-          }}
+          tooltipObj={{ name: "Pattern", icon: <MdPattern className={styles.icon} />, subMenu: patternArr }}
+          onClick={(e, id) => { closeSidebar(); handlePatternClick(id); }}
         />
       </div>
     </>

--- a/src/components/Sidebar/toolTipMenu.js
+++ b/src/components/Sidebar/toolTipMenu.js
@@ -1,72 +1,26 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState } from "react";
 
 const TooltipSubMenu = ({ styles, tooltipObj, onClick }) => {
-  const [tooltipOpen, setTooltipOpen] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   const { name, icon, subMenu } = tooltipObj;
-  const hideTimer = useRef(null);
-  const [pos, setPos] = useState({ top: 0, left: 0 });
-  const ref = useRef();
-
-  useEffect(() => {
-    const checkMobile = () => setIsMobile(window.innerWidth <= 768);
-    checkMobile();
-    window.addEventListener("resize", checkMobile);
-    return () => window.removeEventListener("resize", checkMobile);
-  }, []);
-
-  // Desktop: hover behaviour
-  const showTooltip = () => {
-    if (isMobile) return;
-    clearTimeout(hideTimer.current);
-    const rect = ref.current.getBoundingClientRect();
-    setPos({
-      top:
-        rect.top + rect.height / 2 < 220
-          ? rect.top + rect.height / 2 + 40
-          : rect.top + rect.height / 2,
-      left: rect.right + 5,
-    });
-    setTooltipOpen(true);
-  };
-
-  const hideTooltip = () => {
-    if (isMobile) return;
-    hideTimer.current = setTimeout(() => setTooltipOpen(false), 120);
-  };
-
-  // Mobile: click toggle
-  const handleClick = () => {
-    if (!isMobile) return;
-    setTooltipOpen((prev) => !prev);
-  };
-
-  useEffect(() => {
-    return () => clearTimeout(hideTimer.current);
-  }, []);
 
   return (
     <div
-      ref={ref}
       className={styles.button}
       style={{ position: "relative", flexDirection: "column", alignItems: "flex-start" }}
-      onMouseEnter={showTooltip}
-      onMouseLeave={hideTooltip}
-      onClick={handleClick}
+      onClick={() => setIsOpen((prev) => !prev)}
     >
       {/* Button row */}
       <div style={{ display: "flex", alignItems: "center", gap: 10, width: "100%" }}>
         {icon}
         <span>{name}</span>
-        {isMobile && (
-          <span style={{ marginLeft: "auto", fontSize: 10, opacity: 0.6 }}>
-            {tooltipOpen ? "▲" : "▼"}
-          </span>
-        )}
+        <span style={{ marginLeft: "auto", fontSize: 10, opacity: 0.6 }}>
+          {isOpen ? "▲" : "▼"}
+        </span>
       </div>
 
-      {/* Mobile: inline accordion */}
-      {isMobile && tooltipOpen && (
+      {/* Inline accordion */}
+      {isOpen && (
         <div
           style={{
             width: "100%",
@@ -79,36 +33,7 @@ const TooltipSubMenu = ({ styles, tooltipObj, onClick }) => {
             <div
               className={`${styles.tooltipItem} ${v.isActive ? styles.active : ""}`}
               onClick={(e) => {
-                setTooltipOpen(false);
-                onClick(e, v.id ?? v);
-              }}
-              key={v.id ?? v.value ?? v.label ?? v.name}
-            >
-              {v.name || v.label}
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Desktop: fixed-position flyout */}
-      {!isMobile && tooltipOpen && (
-        <div
-          className={styles.tooltip}
-          style={{
-            position: "fixed",
-            top: pos.top,
-            left: pos.left,
-            zIndex: 9999,
-            minWidth: "210px",
-          }}
-          onMouseEnter={() => clearTimeout(hideTimer.current)}
-          onMouseLeave={hideTooltip}
-        >
-          {subMenu.map((v) => (
-            <div
-              className={`${styles.tooltipItem} ${v.isActive ? styles.active : ""}`}
-              onClick={(e) => {
-                setTooltipOpen(false);
+                setIsOpen(false);
                 onClick(e, v.id ?? v);
               }}
               key={v.id ?? v.value ?? v.label ?? v.name}


### PR DESCRIPTION
remove the hover tooltip logic and use only the mobile click/accordion behavior for all screen sizes in sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated sidebar open/close controls into a single toggle button with adaptive icon and aria-label based on state
  * Simplified submenu interactions by replacing the complex hover/click flyout system with a straightforward click-toggled inline accordion
  * Improved interface consistency and usability across all devices through streamlined control handling and event management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/riyazpanarwala/riyaz-stocks-chart/pull/97)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->